### PR TITLE
merge coverage reports from separate test files

### DIFF
--- a/packages/jest-environment-vite/package.json
+++ b/packages/jest-environment-vite/package.json
@@ -8,14 +8,17 @@
     "@babel/core": "^7.1.2",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
+    "get-port": "^4.0.0",
     "istanbul-api": "^2.0.6",
     "istanbul-lib-coverage": "^2.0.1",
     "jest-environment-selenium": "^1.1.0",
+    "node-ipc": "^9.1.1",
     "stoppable": "^1.0.6",
     "vite-server": "0.0.1"
   },
   "scripts": {
-    "build": "babel src/*.js -d dist"
+    "build": "babel src/*.js -d dist",
+    "watch": "babel src/*.js -d dist -w"
   },
   "devDependencies": {
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",

--- a/packages/jest-environment-vite/src/global-setup.js
+++ b/packages/jest-environment-vite/src/global-setup.js
@@ -1,0 +1,3 @@
+import {setup} from "./shared.js";
+
+module.exports = setup;

--- a/packages/jest-environment-vite/src/global-teardown.js
+++ b/packages/jest-environment-vite/src/global-teardown.js
@@ -1,0 +1,3 @@
+import {teardown} from "./shared.js";
+
+module.exports = teardown;

--- a/packages/jest-environment-vite/src/index.js
+++ b/packages/jest-environment-vite/src/index.js
@@ -1,121 +1,115 @@
 import SeleniumEnvironment from 'jest-environment-selenium';
-
 import {transformSync} from "@babel/core";
-import istanbulApi from "istanbul-api";
 import istanbulLibCoverage from "istanbul-lib-coverage";
-import stoppable from "stoppable";
+import ipc from "node-ipc";
 
 class ViteEnvironment extends SeleniumEnvironment {
-  constructor(config) {
-    super(config);
-    this.global.render = 
-      async data => 
-        await render(this.global.driver, this.coverageMap, data);
-  }
+    constructor(config) {
+        super(config);
+    }
 
-  async setup() {
-    await super.setup();
-    
-    this.server = require("vite-server");
-    stoppable(this.server, 0);
-    this.coverageMap = istanbulLibCoverage.createCoverageMap({});
-    this.containers = [];
-  }
+    async setup() {
+        await super.setup();
+        this.coverageMap = istanbulLibCoverage.createCoverageMap({});
+        this.global.render = this.render.bind(this);
+        this.global.__containers__ = [];
+    }
 
-  async teardown() {
-    await super.teardown();
+    async teardown() {
+        ipc.config.silent = true;
+        ipc.connectTo('vite', () => {
+            ipc.of.vite.on('connect', () => {
+                ipc.of.vite.emit('coverage', this.coverageMap.toJSON());
+            });
+        });
+        await super.teardown();
+    }
 
-    const reporter = istanbulApi.createReporter();
-    reporter.addAll(['json', 'text', 'lcov']);
-    reporter.write(this.coverageMap);
-    this.server.stop(() => console.log("stopping server"));
-  }
+    runScript(script) {
+        return super.runScript(script);
+    }
 
-  runScript(script) {
-    return super.runScript(script);
-  }
+    /**
+     * Renders a React element.
+     * 
+     * `data` can be passed either a React element or a thunk which returns a React element.
+     * 
+     * Note: you must use babel-plugin-vite to transform the test files using this function.  
+     * This plugin looks at all calls to `render` and replaces the first argument with an 
+     * object containing the original source of the argument along with the imports required 
+     * to excute it.
+     * 
+     * e.g.
+     * ```
+     * import Foo from "../foo.js";
+     * 
+     * render(<Foo>Hello, world!</Foo>);
+     * ```
+     * 
+     * will be converted to
+     * ```
+     * import Foo from "../foo.js";
+     * 
+     * render({
+     *     code: "<Foo>Hello, world!</Foo>",
+     *     imports: ["const Foo = (await import(\"../foo.js\")).default;"],
+     * });
+     * ```
+     * 
+     * The reason this is necessary is that node doesn't know how to deal with JSX natively
+     * which means we have to precompile the code to run in node.  The mangles it in such a
+     * way that it's hard to figure out what imports it uses.  We need this information so
+     * that we can generate a snippet of code that can be run inside the browser via Selenium.
+     * 
+     * All code that Selenium runs inside the browser is in a separate context.  While we can
+     * pass some data back and forth between the Selenium context and the node context, we
+     * can't pass classes or functions which is why we have to import all of our dependencies
+     * from within the Selenium context.
+     */
+    async render(data) {
+
+        /**
+         * We use dynamic import statements so that we can run this code without
+         * using a <script> tag.  This allows us to interact with the code we're
+         * running allowing us to create a container element and pass it to the
+         * callback we're passing in.
+         */
+        const lines = [
+            `async () => {`,
+            `const React = (await import("/node_modules/react.js")).default;`,
+            `const ReactDOM = (await import("/node_modules/react-dom.js")).default;`,
+            ...data.imports,
+            `const container = document.createElement("container");`,
+            `document.body.appendChild(container);`,
+        ];
+
+        if (data.code.startsWith("() =>")) {
+            lines.push(`const element = (${data.code})();`);
+        } else {
+            lines.push(`const element = ${data.code};`);
+        }
+
+        lines.push(`ReactDOM.render(element, container, () => callback({container: container, coverage: window.__coverage__}));`);
+        lines.push("}");
+
+        const {code} = transformSync(lines.join("\n"), {
+            plugins: ["@babel/plugin-syntax-dynamic-import"],
+            presets: ["@babel/preset-react"],
+        });
+
+        const script = function (code) {
+            const callback = arguments[arguments.length - 1];
+            const func = new Function("callback", `(${code.slice(0, -1)})()`);
+            func(callback);
+        };
+
+        const {container, coverage} = await this.global.driver.executeAsyncScript(script, code);
+
+        this.coverageMap.merge(coverage);
+        this.global.__containers__.push(container);
+
+        return container;
+    }
 }
 
 module.exports = ViteEnvironment;
-
-/**
- * Renders a React element.
- * 
- * `data` can be passed either a React element or a thunk which returns a React element.
- * 
- * Note: you must use babel-plugin-vite to transform the test files using this function.  
- * This plugin looks at all calls to `render` and replaces the first argument with an 
- * object containing the original source of the argument along with the imports required 
- * to excute it.
- * 
- * e.g.
- * ```
- * import Foo from "../foo.js";
- * 
- * render(<Foo>Hello, world!</Foo>);
- * ```
- * 
- * will be converted to
- * ```
- * import Foo from "../foo.js";
- * 
- * render({
- *     code: "<Foo>Hello, world!</Foo>",
- *     imports: ["const Foo = (await import(\"../foo.js\")).default;"],
- * });
- * ```
- * 
- * The reason this is necessary is that node doesn't know how to deal with JSX natively
- * which means we have to precompile the code to run in node.  The mangles it in such a
- * way that it's hard to figure out what imports it uses.  We need this information so
- * that we can generate a snippet of code that can be run inside the browser via Selenium.
- * 
- * All code that Selenium runs inside the browser is in a separate context.  While we can
- * pass some data back and forth between the Selenium context and the node context, we
- * can't pass classes or functions which is why we have to import all of our dependencies
- * from within the Selenium context.
- */
-export async function render(driver, coverageMap, data) {
-  /**
-   * We use dynamic import statements so that we can run this code without
-   * using a <script> tag.  This allows us to interact with the code we're
-   * running allowing us to create a container element and pass it to the
-   * callback we're passing in.
-   */
-  const lines = [
-      `async () => {`,
-      `const React = (await import("/node_modules/react.js")).default;`,
-      `const ReactDOM = (await import("/node_modules/react-dom.js")).default;`,
-      ...data.imports,
-      `const container = document.createElement("container");`,
-      `document.body.appendChild(container);`,
-  ];
-
-  if (data.code.startsWith("() =>")) {
-      lines.push(`const element = (${data.code})();`);
-  } else {
-      lines.push(`const element = ${data.code};`);
-  }
-
-  lines.push(`ReactDOM.render(element, container, () => callback({container: container, coverage: window.__coverage__}));`);
-  lines.push("}");
-
-  const {code} = transformSync(lines.join("\n"), {
-      plugins: ["@babel/plugin-syntax-dynamic-import"],
-      presets: ["@babel/preset-react"],
-  });
-
-  const script = function (code) {
-      const callback = arguments[arguments.length - 1];
-      const func = new Function("callback", `(${code.slice(0, -1)})()`);
-      func(callback);
-  };
-
-  const {container, coverage} = await driver.executeAsyncScript(script, code);
-
-  coverageMap.merge(coverage);
-  // TODO: clean up containers between test runs
-  // containers.push(container);
-
-  return container;
-}

--- a/packages/jest-environment-vite/src/setup.js
+++ b/packages/jest-environment-vite/src/setup.js
@@ -1,12 +1,5 @@
-import {transformSync} from "@babel/core";
-import istanbulApi from "istanbul-api";
-import istanbulLibCoverage from "istanbul-lib-coverage";
-import stoppable from "stoppable";
-
-let server, coverageMap, containers;
-
 beforeEach(async () => {
-    await driver.get("http://localhost:3000/");
+    await driver.get(`http://localhost:3000/`);
 });
 
 // TODO: provide an option to only call driver.get() once
@@ -14,15 +7,15 @@ beforeEach(async () => {
 // state a test or component might have created.  In some case we may
 // know that no global state is being created in which case only calling
 // driver.get() once will result in faster test runs.
-// afterEach(async () => {
-//     await driver.executeScript((containers) => {
-//         (async () => {
-//             const ReactDOM = (await import("/node_modules/react-dom.js")).default;
-//             for (const container of containers) {
-//                 ReactDOM.unmountComponentAtNode(container);
-//                 document.body.removeChild(container);
-//             }
-//         })();
-//     }, containers);
-//     containers = [];
-// });
+afterEach(async () => {
+    await driver.executeScript((containers) => {
+        (async () => {
+            const ReactDOM = (await import("/node_modules/react-dom.js")).default;
+            for (const container of containers) {
+                ReactDOM.unmountComponentAtNode(container);
+                document.body.removeChild(container);
+            }
+        })();
+    }, __containers__);
+    __containers__.length = 0;
+});

--- a/packages/jest-environment-vite/src/shared.js
+++ b/packages/jest-environment-vite/src/shared.js
@@ -1,0 +1,38 @@
+import createServer from "vite-server";
+import getPort from "get-port";
+import stoppable from "stoppable";
+import ipc from "node-ipc";
+import istanbulApi from "istanbul-api";
+import istanbulLibCoverage from "istanbul-lib-coverage";
+
+let server;
+
+// TODO: make this configurable
+const port = 3000;
+const coverageMaps = [];
+
+export async function setup(config) {
+    server = createServer(port);
+    stoppable(server, 0);
+
+    ipc.config.id = "vite";
+    ipc.config.silent = true;
+    ipc.serve(() => ipc.server.on("coverage", message => {
+        coverageMaps.push(message);
+    }));
+    ipc.server.start();
+}
+
+export async function teardown(config) {
+    server.stop(() => console.log("stopping server"));
+    ipc.server.stop();
+
+    console.log("merging coverage");
+    const coverageMap = istanbulLibCoverage.createCoverageMap({});
+    coverageMaps.forEach(map => coverageMap.merge(map));
+
+    console.log("write coverage report");
+    const reporter = istanbulApi.createReporter();
+    reporter.addAll(['json', 'text', 'lcov']);
+    reporter.write(coverageMap);
+}

--- a/packages/vite-demo/package.json
+++ b/packages/vite-demo/package.json
@@ -6,6 +6,9 @@
   "jest": {
     "testRegex": "/test/.+\\.js$",
     "testEnvironment": "jest-environment-vite",
+    "globalSetup": "../jest-environment-vite/dist/global-setup.js",
+    "globalTeardown": "../jest-environment-vite/dist/global-teardown.js",
+    "setupTestFrameworkScriptFile": "../jest-environment-vite/dist/setup.js",
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",
       "!<rootDir>/util/",

--- a/packages/vite-demo/test/bar.test.js
+++ b/packages/vite-demo/test/bar.test.js
@@ -1,0 +1,9 @@
+import Bar from "../src/bar.js";
+
+describe("bar", () => {
+    test("it should handle components that import other components", async () => {
+        const element = await render(<Bar/>);
+        const text = await element.getText();
+        expect(text).toBe("Hello, world!");
+    });
+});

--- a/packages/vite-demo/test/foo.test.js
+++ b/packages/vite-demo/test/foo.test.js
@@ -1,12 +1,7 @@
 import Foo from "../src/foo.js";
 import Bar from "../src/bar.js";
 
-// TODO: extract this into jest-environment-vite
-beforeEach(async () => {
-    await driver.get("http://localhost:3000/");
-});
-
-describe("selenium tests", () => {
+describe("foo", () => {
     test("the title should be 'Hello, world!'", async () => {     
         const element = await render(<Foo>Hello, world!</Foo>);
         const text = await element.getText();
@@ -18,12 +13,6 @@ describe("selenium tests", () => {
             const msg = "Hello, world!";
             return <Foo>{msg}</Foo>;
         });
-        const text = await element.getText();
-        expect(text).toBe("Hello, world!");
-    });
-
-    test("it should handle components that import other components", async () => {
-        const element = await render(<Bar/>);
         const text = await element.getText();
         expect(text).toBe("Hello, world!");
     });

--- a/packages/vite-server/package.json
+++ b/packages/vite-server/package.json
@@ -23,8 +23,5 @@
   "devDependencies": {
     "babel-plugin-istanbul": "^5.0.1",
     "jest": "^23.6.0"
-  },
-  "bin": {
-    "vite-server": "./server.js"
   }
 }

--- a/packages/vite-server/src/server.js
+++ b/packages/vite-server/src/server.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 const express = require("express");
 const fs = require("fs");
 const path = require("path");
@@ -8,201 +7,203 @@ const commandExists = require("command-exists").sync;
 
 const cjs2es = require("./cjs2es.js");
 
-const app = express();
+module.exports = function createServer(port = 3000) {
+    const app = express();
 
-app.use(express.json());
-
-const modifiers = {
-    shift: false,
-    alt: false,
-    control: false,
-}
-let shift = false;
-
-const getActiveModifiers = () => {
-    return Object.keys(modifiers).filter(key => modifiers[key]);
-}
-
-const mouseDelay = 100;
-const keyboardDelay = 500;
-
-const sleep = async (duration) => 
-    new Promise((resolve, reject) =>
-        setTimeout(resolve, duration));
-
-let screenshotCmd = null;
-if (commandExists("screencapture")) {
-    screenshotCmd = "screencapture";
-} else if (commandExists("import")) {
-    screenshotCmd = "import";
-}
-
-// const config = require(path.join(process.cwd(), "config.json"));
-const config = {
-    screenshots: "screenshots",
-    fixtures: "fixtures",
-};
-
-app.post("/screenshot/:display", (req, res) => {
-    const start = Date.now();
-    const display = req.params.display;
-    const {bounds} = req.body;
-    const filename = path.join(process.cwd(), config.screenshots, req.body.filename);
-    const {x, y, width, height} = bounds;
-
-    let cmd = null;
-    if (screenshotCmd === "screencapture") {
-        cmd = `${screenshotCmd} -R${x},${y},${width},${height} ${filename}`;
-    } else if (screenshotCmd === "import") {
-        cmd = `${screenshotCmd} -display :${display} -window root -crop ${width}x${height}+${x}+${y} ${filename}`;
-    } else {
-        res.status(500);
-        res.end();
+    app.use(express.json());
+    
+    const modifiers = {
+        shift: false,
+        alt: false,
+        control: false,
     }
-
-    console.log(`saving: ${req.body.filename}`);
-
-    child_process.exec(cmd, (err, stdout, stderr) => {
-        if (err) {
-            res.send("failed");
+    let shift = false;
+    
+    const getActiveModifiers = () => {
+        return Object.keys(modifiers).filter(key => modifiers[key]);
+    }
+    
+    const mouseDelay = 100;
+    const keyboardDelay = 500;
+    
+    const sleep = async (duration) => 
+        new Promise((resolve, reject) =>
+            setTimeout(resolve, duration));
+    
+    let screenshotCmd = null;
+    if (commandExists("screencapture")) {
+        screenshotCmd = "screencapture";
+    } else if (commandExists("import")) {
+        screenshotCmd = "import";
+    }
+    
+    // const config = require(path.join(process.cwd(), "config.json"));
+    const config = {
+        screenshots: "screenshots",
+        fixtures: "fixtures",
+    };
+    
+    app.post("/screenshot/:display", (req, res) => {
+        const start = Date.now();
+        const display = req.params.display;
+        const {bounds} = req.body;
+        const filename = path.join(process.cwd(), config.screenshots, req.body.filename);
+        const {x, y, width, height} = bounds;
+    
+        let cmd = null;
+        if (screenshotCmd === "screencapture") {
+            cmd = `${screenshotCmd} -R${x},${y},${width},${height} ${filename}`;
+        } else if (screenshotCmd === "import") {
+            cmd = `${screenshotCmd} -display :${display} -window root -crop ${width}x${height}+${x}+${y} ${filename}`;
         } else {
-            res.send(`screenshot saved to ${req.body.filename}`);
-            const elapsed = Date.now() - start;
-            console.log(`screenshot took ${elapsed}ms`);
+            res.status(500);
+            res.end();
         }
-    });
-});
-
-app.post("/log", (req, res) => {
-    const {message} = req.body;
-    console.log(message);
-    res.send("okay");
-});
-
-const modules = {};
-
-const serveModule = (res, name) => {
-    const filename = name === "@khanacademy/vite-helpers"
-        ? path.join(__dirname, "helpers.js")
-        : path.join(__dirname, '../../../node_modules', name);
-
-    if (!fs.existsSync(filename)) {
-        console.log(`${filename} doesn't exist`);
-        res.status(404);
-        res.end();
-    }
-
-    console.log(`serving: ${name}`);
-    if (name in modules) {
-        res.type('js');
-        res.send(modules[name]);
-    } else {
-        cjs2es(name).then(code => {
-            res.type('js');
-            res.send(code);
-            modules[name] = code;
+    
+        console.log(`saving: ${req.body.filename}`);
+    
+        child_process.exec(cmd, (err, stdout, stderr) => {
+            if (err) {
+                res.send("failed");
+            } else {
+                res.send(`screenshot saved to ${req.body.filename}`);
+                const elapsed = Date.now() - start;
+                console.log(`screenshot took ${elapsed}ms`);
+            }
         });
+    });
+    
+    app.post("/log", (req, res) => {
+        const {message} = req.body;
+        console.log(message);
+        res.send("okay");
+    });
+    
+    const modules = {};
+    
+    const serveModule = (res, name) => {
+        const filename = name === "@khanacademy/vite-helpers"
+            ? path.join(__dirname, "helpers.js")
+            : path.join(__dirname, '../../../node_modules', name);
+    
+        if (!fs.existsSync(filename)) {
+            console.log(`${filename} doesn't exist`);
+            res.status(404);
+            res.end();
+        }
+    
+        console.log(`serving: ${name}`);
+        if (name in modules) {
+            res.type('js');
+            res.send(modules[name]);
+        } else {
+            cjs2es(name).then(code => {
+                res.type('js');
+                res.send(code);
+                modules[name] = code;
+            });
+        }
     }
+    
+    // compile node modules on the fly to ES6 modules
+    app.get("/node_modules/:module.js", (req, res) => {
+        console.log("requesting a module");
+        const name = req.params.module;
+        serveModule(res, name);
+    });
+    
+    app.get("/node_modules/:scope/:module", (req, res) => {
+        const name = req.params.module;
+        const scope = req.params.scope;
+        serveModule(res, `${scope}/${name}`);
+    });
+    
+    app.get('/fixtures', (req, res) => {
+        const fixtures = fs.readdirSync(config.fixtures);
+        console.log(`fixtures: ${fixtures.join(', ')}`);
+    
+        res.type('json');
+        res.send(fixtures);
+    });
+    
+    app.post('/finish/:runner', (req, res) => {
+        const runner = req.params.runner;
+        if (browsers[runner]) {
+            browsers[runner].kill('SIGHUP');
+        }
+        process.exit();
+    });
+    
+    const compile = (filename) => {
+        const src = fs.readFileSync(filename).toString();
+        const relativePath = path.relative(process.cwd(), filename);
+    
+        const code = transformSync(src, {
+            plugins: ["@babel/plugin-syntax-dynamic-import", "istanbul"],
+            presets: ["@babel/preset-react"],
+            filename: relativePath,
+            babelrc: false,
+        }).code;
+    
+        return code.replace(/from\s+\"([^\"\.\/][^\"]+)\"/g, 
+            (match, group1, offset, string) => `from "/node_modules/${group1}.js"`);
+    }
+    
+    const serveJsFile = (req, res, filename) => {
+        if (!fs.existsSync(filename)) {
+            console.log(`${filename} doesn't exist`);
+            res.status(404);
+            res.end();
+        }
+    
+        // TODO(kevinb): cache compiled code and update cache when code changes
+        console.log(`serving: ${req.path} using ${filename}`);
+        res.type('js');
+        res.send(compile(filename));
+    }
+    
+    app.get('/fixtures/*.js', (req, res) => {
+        const filename = path.join(
+            config.fixtures, 
+            path.relative('fixtures', req.path.slice(1)),
+        );
+    
+        serveJsFile(req, res, filename);
+    });
+    
+    // compile all JS files with sucrase to get convert JSX to plain JS
+    app.get('*.js', (req, res) => {
+        const filename = req.path.slice(1);
+        const fullPath = filename === "index.js"
+            ? path.join(__dirname, filename)
+            : path.join(process.cwd(), filename);
+    
+        serveJsFile(req, res, fullPath);
+    });
+    
+    const indexHandler = (req, res) => {
+        const filename = req.path.slice(1);
+        const fullPath = path.join(__dirname, "index.html");
+    
+        if (!fs.existsSync(fullPath)) {
+            console.log(`${fullPath} doesn't exist`);
+            res.status(404);
+            res.end();
+        }
+    
+        console.log(`serving: ${filename}`);
+        const contents = fs.readFileSync(fullPath).toString();
+        res.type('html');
+        res.send(contents);
+    };
+    
+    app.get('/index.html', indexHandler);
+    app.get('/', indexHandler);
+    
+    const server = app.listen(port, () => console.log(`listening on port ${port}`));
+    
+    // TODO: check process.platform and start appropriate browser
+    const browsers = [];
+
+    return server;
 }
-
-// compile node modules on the fly to ES6 modules
-app.get("/node_modules/:module.js", (req, res) => {
-    console.log("requesting a module");
-    const name = req.params.module;
-    serveModule(res, name);
-});
-
-app.get("/node_modules/:scope/:module", (req, res) => {
-    const name = req.params.module;
-    const scope = req.params.scope;
-    serveModule(res, `${scope}/${name}`);
-});
-
-app.get('/fixtures', (req, res) => {
-    const fixtures = fs.readdirSync(config.fixtures);
-    console.log(`fixtures: ${fixtures.join(', ')}`);
-
-    res.type('json');
-    res.send(fixtures);
-});
-
-app.post('/finish/:runner', (req, res) => {
-    const runner = req.params.runner;
-    if (browsers[runner]) {
-        browsers[runner].kill('SIGHUP');
-    }
-    process.exit();
-});
-
-const compile = (filename) => {
-    const src = fs.readFileSync(filename).toString();
-    const relativePath = path.relative(process.cwd(), filename);
-
-    const code = transformSync(src, {
-        plugins: ["@babel/plugin-syntax-dynamic-import", "istanbul"],
-        presets: ["@babel/preset-react"],
-        filename: relativePath,
-        babelrc: false,
-    }).code;
-
-    return code.replace(/from\s+\"([^\"\.\/][^\"]+)\"/g, 
-        (match, group1, offset, string) => `from "/node_modules/${group1}.js"`);
-}
-
-const serveJsFile = (req, res, filename) => {
-    if (!fs.existsSync(filename)) {
-        console.log(`${filename} doesn't exist`);
-        res.status(404);
-        res.end();
-    }
-
-    // TODO(kevinb): cache compiled code and update cache when code changes
-    console.log(`serving: ${req.path} using ${filename}`);
-    res.type('js');
-    res.send(compile(filename));
-}
-
-app.get('/fixtures/*.js', (req, res) => {
-    const filename = path.join(
-        config.fixtures, 
-        path.relative('fixtures', req.path.slice(1)),
-    );
-
-    serveJsFile(req, res, filename);
-});
-
-// compile all JS files with sucrase to get convert JSX to plain JS
-app.get('*.js', (req, res) => {
-    const filename = req.path.slice(1);
-    const fullPath = filename === "index.js"
-        ? path.join(__dirname, filename)
-        : path.join(process.cwd(), filename);
-
-    serveJsFile(req, res, fullPath);
-});
-
-const indexHandler = (req, res) => {
-    const filename = req.path.slice(1);
-    const fullPath = path.join(__dirname, "index.html");
-
-    if (!fs.existsSync(fullPath)) {
-        console.log(`${fullPath} doesn't exist`);
-        res.status(404);
-        res.end();
-    }
-
-    console.log(`serving: ${filename}`);
-    const contents = fs.readFileSync(fullPath).toString();
-    res.type('html');
-    res.send(contents);
-};
-
-app.get('/index.html', indexHandler);
-app.get('/', indexHandler);
-
-const server = app.listen(3000, () => console.log("listening on port 3000"));
-
-// TODO: check process.platform and start appropriate browser
-const browsers = [];
-
-module.exports = server;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1610,6 +1610,10 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
+easy-stack@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/easy-stack/-/easy-stack-1.0.0.tgz#12c91b3085a37f0baa336e9486eac4bf94e3e788"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -1699,6 +1703,10 @@ esutils@^2.0.0, esutils@^2.0.2:
 etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+
+event-pubsub@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/event-pubsub/-/event-pubsub-4.3.0.tgz#f68d816bc29f1ec02c539dc58c8dd40ce72cb36e"
 
 exec-sh@^0.2.0:
   version "0.2.2"
@@ -1992,6 +2000,10 @@ gauge@~2.7.3:
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
+
+get-port@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-4.0.0.tgz#373c85960138ee20027c070e3cb08019fea29816"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -2915,6 +2927,16 @@ js-levenshtein@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.3.tgz#3ef627df48ec8cf24bacf05c0f184ff30ef413c5"
 
+js-message@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/js-message/-/js-message-1.0.5.tgz#2300d24b1af08e89dd095bc1a4c9c9cfcb892d15"
+
+js-queue@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/js-queue/-/js-queue-2.0.0.tgz#362213cf860f468f0125fc6c96abc1742531f948"
+  dependencies:
+    easy-stack "^1.0.0"
+
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -3330,6 +3352,14 @@ negotiator@0.6.1:
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+
+node-ipc@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/node-ipc/-/node-ipc-9.1.1.tgz#4e245ed6938e65100e595ebc5dc34b16e8dd5d69"
+  dependencies:
+    event-pubsub "4.3.0"
+    js-message "1.0.5"
+    js-queue "2.0.0"
 
 node-notifier@^5.2.1:
   version "5.2.1"


### PR DESCRIPTION
Up till now I've only been testing using a single test file.  Adding addition test files caused issues running jest-server and reporting coverage because each `jest` instantiates a new `ViteEnvironment` object for each test file that it processes.

This PR fixes that by using `globalSetup` and `globalTeardown` settings to run code to start `vite-server` once for all tests.  It also handles coverage by communicate the coverage reports for each test file between the jest workers and the global teardown script using `node-ipc`.