### PR TITLE
add collectCoverage option within testEnvironmentOptions, use existing verbose option to toggle extra logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Example config:
       },
       "collectCoverage": true
     },
-    "globalSetup": "../jest-environment-vite/dist/global-setup.js",
-    "globalTeardown": "../jest-environment-vite/dist/global-teardown.js",
-    "setupTestFrameworkScriptFile": "../jest-environment-vite/dist/setup.js",
+    "globalSetup": "jest-environment-vite/dist/global-setup.js",
+    "globalTeardown": "jest-environment-vite/dist/global-teardown.js",
+    "setupTestFrameworkScriptFile": "jest-environment-vite/dist/setup.js",
     "verbose": false
   }
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,39 @@ a `TAB` keypress event with JavaScript which is what `enzyme` does.
 - cd ../vite-demo
 - yarn test
 
+## Configuration
+
+Example config:
+```
+  "jest": {
+    "testRegex": "/test/.+\\.js$",
+    "testEnvironment": "jest-environment-vite",
+    "testEnvironmentOptions": {
+      "capabilities": {
+        "browserName": "chrome",
+        "chromeOptions": {
+          "args": [
+            "headless",
+            "disable-gpu"
+          ]
+        }
+      },
+      "collectCoverage": true
+    },
+    "globalSetup": "../jest-environment-vite/dist/global-setup.js",
+    "globalTeardown": "../jest-environment-vite/dist/global-teardown.js",
+    "setupTestFrameworkScriptFile": "../jest-environment-vite/dist/setup.js",
+    "verbose": false
+  }
+```
+
+**Notes**:
+- `collectCoverage` must be specified within `testEnvironmentOptions`.  This
+  is because the way `jest-environment-vite` collects coverage is incompatible
+  with the default jest test runner.
+- `testEnvironmentOptions` are passed through to `jest-environment-selenium`
+  with the `capabilities` section being passed through to `webdriver.Builder().withCapabilities()`.
+
 ## Architecture
 
 The system is comprised of two main parts:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ import statements without it.
 - [x] coverage
 - [ ] run tests in different browsers
 - [x] extract utils from vite-demo into jest-environment-vite
-- [ ] add config options to jest-environment-vite to toggle debug output from vite-server
+- [x] add config options to jest-environment-vite to toggle debug output from vite-server
 - [ ] run tests inside docker
 - [ ] add ability to take screenshots
 - [ ] comparison new screenshots against existing snapshots

--- a/packages/jest-environment-vite/src/shared.js
+++ b/packages/jest-environment-vite/src/shared.js
@@ -41,7 +41,7 @@ export async function teardown(config) {
     
         logger.log("writing coverage report");
         const reporter = istanbulApi.createReporter();
-        reporter.addAll(['json', 'text', 'lcov']);
+        reporter.addAll(config.coverageReporters);
         reporter.write(coverageMap);
     }
 }

--- a/packages/jest-environment-vite/src/shared.js
+++ b/packages/jest-environment-vite/src/shared.js
@@ -1,18 +1,16 @@
 import createServer from "vite-server";
-import getPort from "get-port";
 import stoppable from "stoppable";
 import ipc from "node-ipc";
 import istanbulApi from "istanbul-api";
 import istanbulLibCoverage from "istanbul-lib-coverage";
 
 let server;
-
-// TODO: make this configurable
-const port = 3000;
 const coverageMaps = [];
 
 export async function setup(config) {
-    server = createServer(port);
+    const port = 3000;
+    const {verbose} = config;
+    server = createServer({port, verbose});
     stoppable(server, 0);
 
     ipc.config.id = "vite";
@@ -24,15 +22,26 @@ export async function setup(config) {
 }
 
 export async function teardown(config) {
-    server.stop(() => console.log("stopping server"));
+    const logger = {
+        log(...args) {
+            if (verbose) {
+                console.log(...args);
+            }
+        },
+    };
+
+    server.stop(() => logger.log("stopping server"));
     ipc.server.stop();
+    const {verbose} = config;
 
-    console.log("merging coverage");
-    const coverageMap = istanbulLibCoverage.createCoverageMap({});
-    coverageMaps.forEach(map => coverageMap.merge(map));
-
-    console.log("writing coverage report");
-    const reporter = istanbulApi.createReporter();
-    reporter.addAll(['json', 'text', 'lcov']);
-    reporter.write(coverageMap);
+    if (coverageMaps.length > 0) {
+        logger.log("merging coverage");
+        const coverageMap = istanbulLibCoverage.createCoverageMap({});
+        coverageMaps.forEach(map => coverageMap.merge(map));
+    
+        logger.log("writing coverage report");
+        const reporter = istanbulApi.createReporter();
+        reporter.addAll(['json', 'text', 'lcov']);
+        reporter.write(coverageMap);
+    }
 }

--- a/packages/vite-demo/package.json
+++ b/packages/vite-demo/package.json
@@ -15,16 +15,13 @@
             "disable-gpu"
           ]
         }
-      }
+      },
+      "collectCoverage": true
     },
     "globalSetup": "../jest-environment-vite/dist/global-setup.js",
     "globalTeardown": "../jest-environment-vite/dist/global-teardown.js",
     "setupTestFrameworkScriptFile": "../jest-environment-vite/dist/setup.js",
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx}",
-      "!<rootDir>/util/",
-      "!<rootDir>/test/"
-    ]
+    "verbose": false
   },
   "dependencies": {
     "aphrodite": "^2.2.3",

--- a/packages/vite-demo/package.json
+++ b/packages/vite-demo/package.json
@@ -18,9 +18,9 @@
       },
       "collectCoverage": true
     },
-    "globalSetup": "../jest-environment-vite/dist/global-setup.js",
-    "globalTeardown": "../jest-environment-vite/dist/global-teardown.js",
-    "setupTestFrameworkScriptFile": "../jest-environment-vite/dist/setup.js",
+    "globalSetup": "jest-environment-vite/dist/global-setup.js",
+    "globalTeardown": "jest-environment-vite/dist/global-teardown.js",
+    "setupTestFrameworkScriptFile": "jest-environment-vite/dist/setup.js",
     "verbose": false
   },
   "dependencies": {


### PR DESCRIPTION
People may not always want to collect coverage.  Also, showing the server logs on the console all of the time is annoying.  In the future though we probably want logging to go to a log file regardless of whether `verbose` is set or not.  Also, it'd be nice to differentiate logs from `jest-environment-vite` and `vita-server`.  This is good enough for now.

This PR also adds an example config so that people will know how to set this up in other projects.  We still need to publish the packages, but in the meantime a person could use `node link`.