### PR TITLE
make class properties tested code work

### DIFF
--- a/packages/jest-environment-vite/package.json
+++ b/packages/jest-environment-vite/package.json
@@ -13,6 +13,8 @@
     "istanbul-lib-coverage": "^2.0.1",
     "jest-environment-selenium": "^1.1.0",
     "node-ipc": "^9.1.1",
+    "request": "^2.88.0",
+    "request-promise-native": "^1.0.5",
     "stoppable": "^1.0.6",
     "vite-server": "0.0.1"
   },

--- a/packages/jest-environment-vite/src/shared.js
+++ b/packages/jest-environment-vite/src/shared.js
@@ -4,6 +4,7 @@ import stoppable from "stoppable";
 import ipc from "node-ipc";
 import istanbulApi from "istanbul-api";
 import istanbulLibCoverage from "istanbul-lib-coverage";
+import rp from "request-promise-native";
 
 let server;
 
@@ -14,10 +15,26 @@ const coverageMaps = [];
 const cache = {};
 
 export async function setup(config) {
+    const logger = {
+        log(...args) {
+            if (verbose) {
+                console.log(...args);
+            }
+        },
+    };
+
     const port = 3000;
     const {verbose} = config;
     server = createServer({port, verbose, cache});
     stoppable(server, 0);
+
+    // TODO: automatically determine dependencies for the package being tested
+    logger.log("compiling react");
+    await rp("http://localhost:3000/node_modules/react.js");
+    logger.log("compiling react-dom");
+    await rp("http://localhost:3000/node_modules/react-dom.js");
+    logger.log("compiling aphrodite");
+    await rp("http://localhost:3000/node_modules/aphrodite.js");
 
     ipc.config.id = "vite";
     ipc.config.silent = true;

--- a/packages/vite-demo/.babelrc.js
+++ b/packages/vite-demo/.babelrc.js
@@ -1,6 +1,7 @@
 module.exports = {
     "presets": ["@babel/react"],
     "plugins": [
+        "@babel/plugin-proposal-class-properties",
         "@babel/plugin-transform-modules-commonjs",
         "@babel/plugin-transform-flow-strip-types",
         "@babel/plugin-syntax-dynamic-import",

--- a/packages/vite-demo/package.json
+++ b/packages/vite-demo/package.json
@@ -30,11 +30,15 @@
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",
+    "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@babel/plugin-transform-modules-commonjs": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
+    "babel-core": "^7.0.0-bridge.0",
+    "babel-jest": "^23.6.0",
     "babel-plugin-vite": "0.0.1",
+    "jest": "^23.6.0",
     "jest-environment-vite": "0.0.1"
   },
   "scripts": {

--- a/packages/vite-demo/src/hidden-button.js
+++ b/packages/vite-demo/src/hidden-button.js
@@ -1,0 +1,14 @@
+// @flow
+import * as React from "react";
+
+export default class HiddenButton extends React.Component<{}> {
+    handleClick = () => {
+        console.log("click me");
+    }
+
+    render() {
+        return <div>
+            <button onClick={this.handleClick}>Click me!</button>
+        </div>
+    }
+}

--- a/packages/vite-demo/src/hidden-button.js
+++ b/packages/vite-demo/src/hidden-button.js
@@ -3,6 +3,7 @@ import * as React from "react";
 
 export default class HiddenButton extends React.Component<{}> {
     handleClick = () => {
+        // eslint-disable-next-line no-console
         console.log("click me");
     }
 

--- a/packages/vite-demo/test/hidden-button.js
+++ b/packages/vite-demo/test/hidden-button.js
@@ -1,0 +1,10 @@
+// @flow
+import HiddenButton from "../src/hidden-button.js";
+
+describe("HiddenButton", () => {
+    test("it should render", async () => {     
+        const element = await render(<HiddenButton/>);
+        const text = await element.getText();
+        expect(text).toBe("Click me!");
+    });
+});

--- a/packages/vite-server/package.json
+++ b/packages/vite-server/package.json
@@ -8,9 +8,11 @@
   },
   "dependencies": {
     "@babel/core": "^7.1.2",
+    "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
+    "babel-plugin-istanbul": "^5.0.1",
     "command-exists": "^1.2.7",
     "express": "^4.16.3",
     "react": "^16.5.2",
@@ -20,9 +22,5 @@
     "rollup-plugin-auto-external": "^2.0.0",
     "rollup-plugin-commonjs": "^9.1.8",
     "rollup-plugin-node-resolve": "^3.4.0"
-  },
-  "devDependencies": {
-    "babel-plugin-istanbul": "^5.0.1",
-    "jest": "^23.6.0"
   }
 }

--- a/packages/vite-server/src/server.js
+++ b/packages/vite-server/src/server.js
@@ -137,14 +137,21 @@ module.exports = function createServer(options) {
         const relativePath = path.relative(process.cwd(), filename);
     
         const code = transformSync(src, {
+            // use plugins and presets from vite-server
             plugins: [
-                "@babel/plugin-syntax-dynamic-import", 
-                "@babel/plugin-transform-flow-strip-types", 
-                "istanbul",
+                require("@babel/plugin-proposal-class-properties"),
+                require("@babel/plugin-syntax-dynamic-import"), 
+                require("@babel/plugin-transform-flow-strip-types"), 
+                require("babel-plugin-istanbul"),
             ],
-            presets: ["@babel/preset-react"],
+            presets: [
+                require("@babel/preset-react"),
+            ],
             filename: relativePath,
+            // prevent .babelrc(.js)? from package under test affecting compilation
             babelrc: false,
+            // prevent babel.config.js from package under test affecting compilation
+            configFile: false,
         }).code;
     
         return code.replace(/from\s+"([^"./][^"]+)"/g, 

--- a/yarn.lock
+++ b/yarn.lock
@@ -252,6 +252,15 @@
     "@babel/traverse" "^7.0.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-replace-supers@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz#5fc31de522ec0ef0899dc9b3e7cf6a5dd655f362"
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
 "@babel/helper-simple-access@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.0.0.tgz#ff36a27983ae4c27122da2f7f294dced80ecbd08"
@@ -339,6 +348,17 @@
     "@babel/helper-remap-async-to-generator" "^7.0.0"
     "@babel/plugin-syntax-async-generators" "^7.0.0"
 
+"@babel/plugin-proposal-class-properties@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz#9af01856b1241db60ec8838d84691aa0bd1e8df4"
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.1.0"
+    "@babel/plugin-syntax-class-properties" "^7.0.0"
+
 "@babel/plugin-proposal-json-strings@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz#3b4d7b5cf51e1f2e70f52351d28d44fc2970d01e"
@@ -371,6 +391,12 @@
 "@babel/plugin-syntax-async-generators@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz#bf0891dcdbf59558359d0c626fdc9490e20bc13c"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-class-properties@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz#e051af5d300cbfbcec4a7476e37a803489881634"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -826,16 +852,16 @@ acorn-jsx@^4.1.1:
     acorn "^5.0.3"
 
 acorn-walk@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.0.1.tgz#c7827bdbb8e21aa97b609adfa225400d9ae348ba"
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.0.tgz#c957f4a1460da46af4a0388ce28b4c99355b0cbc"
 
 acorn@^5.0.3, acorn@^5.5.3, acorn@^5.6.0:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
 
 acorn@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.1.tgz#66e6147e1027704479dc6d9b20d884c572db3cc1"
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.2.tgz#6a459041c320ab17592c6317abbfdf4bbaa98ca4"
 
 ajv@^5.3.0:
   version "5.5.2"
@@ -1295,8 +1321,8 @@ braces@^2.3.0, braces@^2.3.1:
     to-regex "^3.0.1"
 
 browser-process-hrtime@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
 
 browser-resolve@^1.11.3:
   version "1.11.3"
@@ -1491,9 +1517,15 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
-combined-stream@1.0.6, combined-stream@~1.0.6:
+combined-stream@1.0.6:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  resolved "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
+
+combined-stream@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
   dependencies:
     delayed-stream "~1.0.0"
 
@@ -2395,7 +2427,7 @@ get-stdin@^6.0.0:
 
 get-stream@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  resolved "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -2607,13 +2639,7 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@0.4.23:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
-
-iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
@@ -4544,7 +4570,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.87.0:
+request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   dependencies:
@@ -4937,18 +4963,17 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.2.tgz#c6fc61648a3d9c4e764fd3fcdf4ea105e492ba98"
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.15.1.tgz#b79a089a732e346c6e0714830f36285cd38191a2"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
-    dashdash "^1.12.0"
-    getpass "^0.1.1"
-    safer-buffer "^2.0.2"
-  optionalDependencies:
     bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
     ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
     jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
 stack-utils@^1.0.1:
@@ -5336,10 +5361,10 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.4.tgz#63fb016b7435b795d9025632c086a5209dbd2621"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
   dependencies:
-    iconv-lite "0.4.23"
+    iconv-lite "0.4.24"
 
 whatwg-mimetype@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
Because `vite-server` is imported and run within the `vite-demo` folder it was using the .babelrc.js (or babel.config.js) in that folder to compile source .js files requested by selenium.  The problem with this is that `vite-server` is not supposed to compile import/export to commonjs, but `vite-demo` must (because that code there is running in node+jest).

This PR ensures that `vite-server` is using only the babel plugins and preset specified in vite-server/server.js.  As part of this work I also ran into a situation where the tests were timing out.  The default jest timeout is 5000ms and having three concurrent tests running resulted in the server trying to compile `react`, `react-dom`, and `aphrodite` each time thrice which resulted in the server taking to long to serve those files.  To address this I've added some code to prime `vite-server`'s module cache by requesting `/node_modules/react.js`, etc. before running the tests.