### PR TITLE
report coverage after each test instead after each render

### DIFF
--- a/packages/jest-environment-vite/src/index.js
+++ b/packages/jest-environment-vite/src/index.js
@@ -1,7 +1,6 @@
 import SeleniumEnvironment from 'jest-environment-selenium';
 import {transformSync} from "@babel/core";
 import istanbulLibCoverage from "istanbul-lib-coverage";
-import ipc from "node-ipc";
 
 class ViteEnvironment extends SeleniumEnvironment {
     constructor(config) {
@@ -19,14 +18,14 @@ class ViteEnvironment extends SeleniumEnvironment {
     }
 
     async teardown() {
-        if (this.collectCoverage) {
-            ipc.config.silent = true;
-            ipc.connectTo('vite', () => {
-                ipc.of.vite.on('connect', () => {
-                    ipc.of.vite.emit('coverage', this.coverageMap.toJSON());
-                });
-            });
-        }
+        // if (this.collectCoverage) {
+        //     ipc.config.silent = true;
+        //     ipc.connectTo('vite', () => {
+        //         ipc.of.vite.on('connect', () => {
+        //             ipc.of.vite.emit('coverage', this.coverageMap.toJSON());
+        //         });
+        //     });
+        // }
         await super.teardown();
     }
 
@@ -94,7 +93,7 @@ class ViteEnvironment extends SeleniumEnvironment {
             lines.push(`const element = ${data.code};`);
         }
 
-        lines.push(`ReactDOM.render(element, container, () => callback({container: container, coverage: window.__coverage__}));`);
+        lines.push(`ReactDOM.render(element, container, () => callback(container));`);
         lines.push("}");
 
         const {code} = transformSync(lines.join("\n"), {
@@ -109,11 +108,7 @@ class ViteEnvironment extends SeleniumEnvironment {
             func(callback);
         };
 
-        const {container, coverage} = await this.global.driver.executeAsyncScript(script, code);
-
-        if (this.collectCoverage) {
-            this.coverageMap.merge(coverage);
-        }
+        const container = await this.global.driver.executeAsyncScript(script, code);
         this.global.__containers__.push(container);
 
         return container;

--- a/packages/jest-environment-vite/src/index.js
+++ b/packages/jest-environment-vite/src/index.js
@@ -18,14 +18,6 @@ class ViteEnvironment extends SeleniumEnvironment {
     }
 
     async teardown() {
-        // if (this.collectCoverage) {
-        //     ipc.config.silent = true;
-        //     ipc.connectTo('vite', () => {
-        //         ipc.of.vite.on('connect', () => {
-        //             ipc.of.vite.emit('coverage', this.coverageMap.toJSON());
-        //         });
-        //     });
-        // }
         await super.teardown();
     }
 

--- a/packages/jest-environment-vite/src/setup.js
+++ b/packages/jest-environment-vite/src/setup.js
@@ -1,3 +1,5 @@
+import ipc from "node-ipc";
+
 beforeEach(async () => {
     await driver.get(`http://localhost:3000/`);
 });
@@ -8,6 +10,16 @@ beforeEach(async () => {
 // know that no global state is being created in which case only calling
 // driver.get() once will result in faster test runs.
 afterEach(async () => {
+    const coverage = await driver.executeScript("return window.__coverage__");
+
+    ipc.config.silent = true;
+    ipc.connectTo('vite', () => {
+        ipc.of.vite.on('connect', () => {
+            ipc.of.vite.emit('coverage', coverage);
+            ipc.disconnect('vite');
+        });
+    });
+
     await driver.executeScript((containers) => {
         (async () => {
             const ReactDOM = (await import("/node_modules/react-dom.js")).default;

--- a/packages/vite-demo/src/hidden-button.js
+++ b/packages/vite-demo/src/hidden-button.js
@@ -2,14 +2,17 @@
 import * as React from "react";
 
 export default class HiddenButton extends React.Component<{}> {
+    state = {
+        clicked: false,
+    }
+
     handleClick = () => {
-        // eslint-disable-next-line no-console
-        console.log("click me");
+        this.setState({clicked: true});
     }
 
     render() {
-        return <div>
-            <button onClick={this.handleClick}>Click me!</button>
-        </div>
+        return <button onClick={this.handleClick}>
+            {this.state.clicked ? "clicked" : "no yet"}
+        </button>;
     }
 }

--- a/packages/vite-demo/test/hidden-button.test.js
+++ b/packages/vite-demo/test/hidden-button.test.js
@@ -4,7 +4,9 @@ import HiddenButton from "../src/hidden-button.js";
 describe("HiddenButton", () => {
     test("it should render", async () => {     
         const element = await render(<HiddenButton/>);
+        const actions = driver.actions();
+        await actions.click(element).perform();
         const text = await element.getText();
-        expect(text).toBe("Click me!");
+        expect(text).toBe("clicked");
     });
 });


### PR DESCRIPTION
We were reporting coverage immediately after `render` instead of waiting until after each test.  This meant that lines that were being run in response to simulated events were not being counted.  This PR fixes that.