### PR TITLE
add focus handling tests

### DIFF
--- a/packages/vite-demo/test/focus.test.js
+++ b/packages/vite-demo/test/focus.test.js
@@ -68,3 +68,4 @@ describe("focus handling", () => {
         expect(await element.getText()).toBe("bar");
     });
 });
+

--- a/packages/vite-demo/test/focus.test.js
+++ b/packages/vite-demo/test/focus.test.js
@@ -1,0 +1,70 @@
+/* global By */
+// @flow
+describe("focus handling", () => {
+    test("pressing tab should switch focus", async () => {     
+        await render(<div>
+            <button>foo</button>
+            <button>bar</button>
+        </div>);
+
+        const TAB = "\ue004";
+
+        let element;
+        let text;
+
+        await driver.actions().sendKeys(TAB).perform();
+        element = await driver.switchTo().activeElement();
+        text = await element.getText();
+        expect(text).toBe("foo");
+
+        await driver.actions().sendKeys(TAB).perform();
+        element = await driver.switchTo().activeElement();
+        text = await element.getText();
+        expect(text).toBe("bar");
+
+        // tabbing again makes the body active
+        await driver.actions().sendKeys(TAB).perform();
+        element = await driver.switchTo().activeElement();
+        expect(await element.getTagName()).toBe("body");
+
+        // tabbing again selects the first item
+        await driver.actions().sendKeys(TAB).perform();
+        element = await driver.switchTo().activeElement();
+        text = await element.getText();
+        expect(text).toBe("foo");
+    });
+
+    test("programmatic changing focus", async () => {
+        await render(<div>
+            <button id="foo">foo</button>
+            <button id="bar">bar</button>
+        </div>);
+
+        const focus = async (element) => 
+            await driver.executeScript((element) => {
+                element.focus();
+            }, element);
+
+        const blur = async (element) => 
+            await driver.executeScript((element) => {
+                element.blur();
+            }, element);
+
+        const foo = await driver.findElement(By.id("foo"));
+        const bar = await driver.findElement(By.id("bar"));
+
+        let element;
+
+        await focus(foo);
+        element = await driver.switchTo().activeElement();
+        expect(await element.getText()).toBe("foo");
+
+        await blur(foo);
+        element = await driver.switchTo().activeElement();
+        expect(await element.getTagName()).toBe("body");
+
+        await focus(bar);
+        element = await driver.switchTo().activeElement();
+        expect(await element.getText()).toBe("bar");
+    });
+});

--- a/packages/vite-demo/test/focus.test.js
+++ b/packages/vite-demo/test/focus.test.js
@@ -68,4 +68,3 @@ describe("focus handling", () => {
         expect(await element.getText()).toBe("bar");
     });
 });
-

--- a/packages/vite-demo/test/hidden-button.test.js
+++ b/packages/vite-demo/test/hidden-button.test.js
@@ -10,8 +10,7 @@ describe("HiddenButton", () => {
         const size = await button.getSize();
         const location = await button.getLocation();
         
-        const actions = driver.actions();
-        await actions.click({
+        await driver.actions().click({
             x: parseInt(location.x + size.width / 2), 
             y: parseInt(location.y + size.height / 2),
         }).perform();
@@ -27,8 +26,7 @@ describe("HiddenButton", () => {
         const size = await button.getSize();
         const location = await button.getLocation();
         
-        const actions = driver.actions();
-        await actions.mouseMove({
+        await driver.actions().mouseMove({
             x: parseInt(location.x + size.width / 2), 
             y: parseInt(location.y + size.height / 2),
         }).click().perform();


### PR DESCRIPTION
These tests verify that focus can be updated programmatically by calling `.focus()` or `.blur()` or by simulating the TAB key being pressed.