### PR TITLE
support object spread

### DIFF
--- a/packages/vite-demo/test/spread.test.js
+++ b/packages/vite-demo/test/spread.test.js
@@ -1,0 +1,17 @@
+// @flow
+import * as React from "react";
+
+describe("bar", () => {
+    test("it should handle components that import other components", async () => {
+        const element = await render(() => {
+            const props = {
+                id: "foo",
+                className: "bar",
+            };
+
+            return <div {...props}>Hello, world!</div>;
+        });
+        const text = await element.getText();
+        expect(text).toBe("Hello, world!");
+    });
+});

--- a/packages/vite-server/package.json
+++ b/packages/vite-server/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@babel/core": "^7.1.2",
     "@babel/plugin-proposal-class-properties": "^7.1.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
     "@babel/preset-react": "^7.0.0",

--- a/packages/vite-server/src/server.js
+++ b/packages/vite-server/src/server.js
@@ -128,8 +128,10 @@ module.exports = function createServer(options) {
     
         const code = transformSync(src, {
             // use plugins and presets from vite-server
+            // TODO(kevninb): make this configurable
             plugins: [
                 require("@babel/plugin-proposal-class-properties"),
+                require("@babel/plugin-proposal-object-rest-spread"),
                 require("@babel/plugin-syntax-dynamic-import"), 
                 require("@babel/plugin-transform-flow-strip-types"), 
                 require("babel-plugin-istanbul"),


### PR DESCRIPTION
The transforms we use in `vite-server` are hard-coded and some of the code wonder-blocks uses object spread which we weren't transforming.  This PR updates `bite-server` to transform object spread.  In the future though we'll want to make this configurable by clients.