### PR TITLE
handle building react-router-dom

### DIFF
--- a/packages/vite-server/src/cjs2es.js
+++ b/packages/vite-server/src/cjs2es.js
@@ -27,7 +27,10 @@ async function build(moduleName) {
     // versions.
     // TODO(kevinb): make this configurable
     const useModule = pkg && pkg.module
-        && (pkg.name.startsWith("@khanacademy") || pkg.name === "react-router-dom" || pkg.name === "history");
+        && (pkg.name.startsWith("@khanacademy") || 
+            pkg.name === "react-router-dom" || 
+            pkg.name === "history" || 
+            pkg.name === "aphrodite");
 
     const input = useModule
         ? res.replace(pkg.main, pkg.module)
@@ -39,7 +42,7 @@ async function build(moduleName) {
     // The reason for this is that some of them may or may not be ES6 modules
     // and rollup doesn't work well when including a CommonJS module from an
     // ES6 module.
-    if (useModule) {
+    if (useModule && pkg.name !== "aphrodite") {
         plugins.push(
             autoExternalPlugin({
                 packagePath: res.replace(pkg.main, "package.json"),
@@ -65,6 +68,10 @@ async function build(moduleName) {
                 },
             })
         );
+    } else if (pkg.name === "aphrodite") {
+        // Fixes MISSING_EXPORT error with aphrodite which is caused by
+        // aphrodite not not having a default export.
+        plugins.push(commonjsPlugin({}));
     }
 
     const inputOptions = {

--- a/packages/vite-server/src/cjs2es.js
+++ b/packages/vite-server/src/cjs2es.js
@@ -21,28 +21,59 @@ async function resolvePkg(moduleName, options) {
 async function build(moduleName) {
     const basedir = process.cwd();
     const {res, pkg} = await resolvePkg(moduleName, {basedir: basedir});
-    const input = res;
 
-    const inputOptions = {
-        input,
-        plugins: [
-            autoExternalPlugin(),
-            resolvePlugin({
-                module: true,
-                jsnext: true,
-                main: true,
-                browser: true,
-            }),
-            commonjsPlugin(pkg.module ? {} : {
+    // We prefer using the modules we're testing (@khanacademy/*) in ES6 form.
+    // There are also some modules which are easier to bundle using their ES6
+    // versions.
+    // TODO(kevinb): make this configurable
+    const useModule = pkg && pkg.module
+        && (pkg.name.startsWith("@khanacademy") || pkg.name === "react-router-dom" || pkg.name === "history");
+
+    const input = useModule
+        ? res.replace(pkg.main, pkg.module)
+        : res;
+
+    const plugins = [];
+    
+    // For ES6 modules we don't want exclude all dependencies from the bundle.
+    // The reason for this is that some of them may or may not be ES6 modules
+    // and rollup doesn't work well when including a CommonJS module from an
+    // ES6 module.
+    if (useModule) {
+        plugins.push(
+            autoExternalPlugin({
+                packagePath: res.replace(pkg.main, "package.json"),
+            })
+        );
+    }
+        
+    plugins.push(
+        resolvePlugin({
+            module: true,
+            jsnext: true,
+            main: true,
+            browser: true,
+        }),
+    );
+
+    // For CommonJS modules we have to provide a list of named exports.
+    if (!useModule) {
+        plugins.push(
+            commonjsPlugin({
                 namedExports: {
                     [input]: Object.keys(require(input)).filter(key => key !== "default"),
                 },
-            }),
-        ],
+            })
+        );
+    }
+
+    const inputOptions = {
+        input,
+        plugins,
     };
 
     const outputOptions = {
-        format: 'es',
+        format: 'esm',
     };
 
     // create a bundle

--- a/packages/vite-server/src/server.js
+++ b/packages/vite-server/src/server.js
@@ -100,7 +100,7 @@ module.exports = function createServer(options) {
         serveModule(res, name);
     });
     
-    app.get("/node_modules/:scope/:module", (req, res) => {
+    app.get("/node_modules/:scope/:module.js", (req, res) => {
         const name = req.params.module;
         const scope = req.params.scope;
         serveModule(res, `${scope}/${name}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6261,6 +6261,10 @@ rollup-plugin-node-resolve@^3.4.0:
     is-module "^1.0.0"
     resolve "^1.1.6"
 
+rollup-plugin-peer-deps-external@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.0.tgz#99ef9231aa01736f3e9605b7c3084a0d627f665b"
+
 rollup-pluginutils@^2.0.1:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz#3aad9b1eb3e7fe8262820818840bf091e5ae6794"


### PR DESCRIPTION
Rollup had trouble building an ES6 bundle from the CommonJS version of `react-router-dom` so I've updated vite-server to use the ES6 build file that started shipping in version 4.4.0-beta of `react-router-dom`.